### PR TITLE
Also bail out if Pageimages is empty

### DIFF
--- a/MarkupMetadata.module.php
+++ b/MarkupMetadata.module.php
@@ -246,6 +246,11 @@ class MarkupMetadata extends WireData implements Module, ConfigurableModule {
       $image = $image->first();
     }
 
+    // Pageimages might be empty
+    if (empty($image)) {
+      return null;
+    }
+
     // Resize image
     if (!empty($this->image_width) && !empty($this->image_height)) {
       return $image->size($this->image_width, $this->image_height);


### PR DESCRIPTION
Hi,

This is a very small PR making sure a Pageimages is not empty and bail out accordingly. I had a case where a Pageimages was empty and the module tried to resize a non-existent image, thus resulting in an error. This fixes it.

Hope it helps,
Romain